### PR TITLE
Fixes craft 3.3 CP malfunctioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To install the plugin, follow these instructions.
 
 2. Then tell Composer to load the plugin:
 
-        composer require 24hoursmedia/comments-work
+        composer require twentyfourhoursmedia/comments-work
 
 3. In the Control Panel, go to Settings → Plugins and click the “Install” button for Comments Work.
 

--- a/src/elements/Comment.php
+++ b/src/elements/Comment.php
@@ -93,7 +93,7 @@ class Comment extends Element
      */
     public static function displayName(): string
     {
-        return Craft::t('comment', '');
+        return Craft::t('comments-work', 'comment');
     }
 
     /**


### PR DESCRIPTION
because translation was not found

comments-work-7 Plugin must work with craft 3.3